### PR TITLE
Force a single response to offensive phrases

### DIFF
--- a/responses/slackbot.js
+++ b/responses/slackbot.js
@@ -39,6 +39,7 @@ module.exports = {
                 if(commandObj.msg.content.toLowerCase().indexOf(phrase)>-1){
                     var message = rand(phrases[phrase]);
                     commandObj.msg.channel.send(message);
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Currently CajunBot responds to every offense within the message, which can sometimes cause too many images to be posted to the chat